### PR TITLE
Add LeaderMultiDisplay

### DIFF
--- a/fairgame.js
+++ b/fairgame.js
@@ -183,7 +183,7 @@ function writeNewRow(body, ranker) {
     if ((ranker.rank === 1 && ranker.growing) && qolOptions.multiLeader[$("#leadermultimode")[0].value]) {
         multiPrice = qolOptions.multiLeader[$("#leadermultimode")[0].value]
         .replace("NUMBER",`${numberFormatter.format(Math.pow(ladderData.currentLadder.number+1, ranker.multiplier+1))}`)
-        .replace("STATUS", `${(ranker.points >= Math.pow(ladderData.currentLadder.number+1, ranker.multiplier+1)) ? "🟩" : "🟥"}`)
+        .replace("STATUS", `${(ranker.power >= Math.pow(ladderData.currentLadder.number+1, ranker.multiplier+1)) ? "🟩" : "🟥"}`)
     }
     row.insertCell(0).innerHTML = rank + assholeTag;
     row.insertCell(1).innerHTML = `[+${ranker.bias.toString().padStart(2,"0")} x${ranker.multiplier.toString().padStart(2,"0")}] ${ranker.username}`+timeToFirst;

--- a/fairgame.js
+++ b/fairgame.js
@@ -418,7 +418,7 @@ $("#offcanvasOptions").children(".offcanvas-body").html(`<div style="display: bl
                        `<div style="display: block; padding: 0.5rem; font-size:1.25rem"><input type="checkbox" id="printFillerRows"><span style="padding: 10px">Append filler rankers</span></div>`+
                        `<div style="display: block; padding: 0.5rem; font-size:1.25rem"><input type="checkbox" id="scrollableTable"><span style="padding: 10px">Make ladder scrollable</span></div>`+
                        `<div style="display: block; padding: 0.5rem; font-size:1.25rem"><input type="checkbox" id="promotePoints"><span style="padding: 10px">Show points for promotion</span></div>`+
-                       `<div style="display: block; padding: 0.5rem; font-size:1.25rem"><span>Leader Power Requirements</span><select name="selector1" id="leadermultimode" class="form-select">
+                       `<div style="display: block; padding: 0.5rem; font-size:1.25rem"><span>Leader Multi Requirement</span><select name="selector1" id="leadermultimode" class="form-select">
                        <option value="Both">[524288 x🟩]</option>
                        <option value="Square">[x🟩 / x🟥]</option>
                        <option value="Number">[524288]</option>


### PR DESCRIPTION
Added a small bar in the ladder that shows how much power rank 1 (the leader) needs to buy a new multi (for effective use of vinegar)
Has the ability to turn off and change between different display modes.

How it looks in the ladder:
![Screenshot_962](https://user-images.githubusercontent.com/38959426/151996361-439966e1-f804-4253-9a32-05d009b1b7f3.png)

Config:
![Screenshot_964](https://user-images.githubusercontent.com/38959426/151996407-e1291c2d-6f46-4565-a06e-66b81edda336.png)

How to add new display modes:
My change includes a very easy modular system, where the current power and status are used to replace fixed strings from the config. Adding new config strings is easy! There are 3 examples given.